### PR TITLE
修复Apple Books不能正确显示生成的epub文件问题 (#27)

### DIFF
--- a/lib/epub_packer/epub_navigator.dart
+++ b/lib/epub_packer/epub_navigator.dart
@@ -39,6 +39,7 @@ class EpubNavigator implements EpubNode {
     _builder.element(
       "ncx",
       attributes: {
+        "version": "2005-1",
         "xmlns": "http://www.daisy.org/z3986/2005/ncx/",
       },
       nest: () {
@@ -65,7 +66,7 @@ class _Head extends EpubChildNode {
         builder.element(
           "meta",
           attributes: {
-            "content": "urn:uuid:$bookUuid",
+            "content": bookUuid,
             "name": "dtb:uid",
           },
         );

--- a/lib/light_novel/base/light_novel_source.dart
+++ b/lib/light_novel/base/light_novel_source.dart
@@ -4,7 +4,7 @@ import 'package:bili_novel_packer/light_novel/base/light_novel_model.dart';
 import 'package:html/dom.dart';
 
 abstract class LightNovelSource {
-  static const String html = "<html lang='zh-CN'><body></body></html>";
+  static const String html = "<html xmlns='http://www.w3.org/1999/xhtml' lang='zh-CN'><body></body></html>";
 
   String get name;
 


### PR DESCRIPTION
根据[Apple官方](https://itunespartner.apple.com/books/support/9-prepare-book)的图书上架说明，所有的epub都要通过epubcheck类工具的检查。

> ### Validate your EPUB file
> 
> All EPUB books submitted to Apple Books must pass the most recent version of [EPUBCheck](https://github.com/w3c/epubcheck). Use one of the available [EPUB validation tools](https://github.com/w3c/epubcheck/wiki/GUI) to check your file. If you validate your EPUB file and get errors, review the [explanation of errors](https://github.com/IDPF/epubcheck/wiki/Errors) from the developers of EPUBCheck.

在使用工具下载了一本有图的哔哩轻小说源的轻小说之后，尝试运行了 [EPUBCheck](https://github.com/w3c/epubcheck)之后发现了这样的报错
于是修改了
- 每个chapter的html加上xmlns属性
- toc.ncx修正格式和补上version标签
```
ERROR(RSC-005): b3.epub/OEBPS/chapter000001.xhtml(1,20): Error while parsing file: elements from namespace "" are not allowed
ERROR(RSC-005): b3.epub/OEBPS/toc.ncx(2,51): Error while parsing file: element "ncx" missing required attribute "version"
ERROR(NCX-001): b3.epub/OEBPS/toc.ncx(-1,-1): NCX identifier ("urn:uuid:8aaca600-54e1-11ef-8301-031545c29b4f") does not match OPF identifier ("8aaca600-54e1-11ef-8301-031545c29b4f").
```
这样就可以正确在Apple Books中显示了。不过还有一些别的报错……诸如
```
ERROR(PKG-006): b3.epub//D:/Novel/epubcheck-5.1.0/b3.epub(-1,-1): Mimetype file entry is missing or is not the first file in the archive.
Validating using EPUB version 2.0.1 rules.
ERROR(RSC-005): b3.epub/OEBPS/content.opf(24,84): Error while parsing file: value of attribute "id" is invalid; must be an XML name without colons
ERROR(RSC-005): b3.epub/OEBPS/content.opf(25,84): Error while parsing file: value of attribute "id" is invalid; must be an XML name without colons
ERROR(RSC-005): b3.epub/OEBPS/content.opf(26,84): Error while parsing file: value of attribute "id" is invalid; must be an XML name without colons
ERROR(RSC-005): b3.epub/OEBPS/content.opf(27,84): Error while parsing file: value of attribute "id" is invalid; must be an XML name without colons
ERROR(OPF-074): b1.epub/OEBPS/content.opf(22,78): Package resource "OEBPS/images/000025.jpg" is declared in several manifest item.
ERROR(RSC-005): b1.epub/OEBPS/chapter000001.xhtml(1,70): Error while parsing file: element "head" incomplete; missing required element "title"
ERROR(RSC-005): b1.epub/OEBPS/chapter000001.xhtml(1,995): Error while parsing file: attribute "data-src" not allowed here; expected attribute "alt", "class", "dir", "height", "id", "ismap", "lang", "longdesc", "style", "title", "usemap", "width" or "xml:lang"
ERROR(RSC-005): b1.epub/OEBPS/chapter000001.xhtml(1,995): Error while parsing file: element "img" missing required attribute "alt"
```
- 根据定义Mimetype文件必须要是打包的内容中的第一个文件
- content.opf中现有的逻辑是取不到id直接以图片的路径为值，诸如```images/000001.jpg```这样就会引入```slash(/)```而xml的规范不允许```underscores, periods (.), and hyphens (-)```之外的特殊符号
- content.opf中最后一张图重复申明了
- chapter的head缺少title
- img的data-src属性不属于xml的合法值（直接去掉就行？
- img缺少alt标签（这个少了就少了吧……毕竟原网页就没有

因为不熟悉dart，主要是第一个mimetype这边的搞不明白就没尝试修复。总之现在能正常显示了，如果作者大大有精力的话也可以根据epubcheck的报错尝试修复……希望能接受这个pr（？