### PR TITLE
Update flutter to 3.35.5 and add riscv64 build support

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -30,7 +30,7 @@ jobs:
       date: ${{ steps.get_version.outputs.date}}
     runs-on: ${{ matrix.os }}
     env:
-      FLUTTER_VERSION: 3.32.8
+      FLUTTER_VERSION: 3.35.5
     steps:
       # Checkout branch
       - name: Checkout
@@ -77,6 +77,7 @@ jobs:
         run: |
           dart compile exe --target-os=linux --target-arch=x64 --output=./bili_novel_packer-${{ steps.get_version.outputs.version }}-x86_64-linux ./bin/main.dart
           dart compile exe --target-os=linux --target-arch=arm64 --output=./bili_novel_packer-${{ steps.get_version.outputs.version }}-arm64-linux ./bin/main.dart
+          dart compile exe --target-os=linux --target-arch=riscv64 --output=./bili_novel_packer-${{ steps.get_version.outputs.version }}-riscv64-linux ./bin/main.dart
 
       # Upload Artifacts
       - name: Upload Artifacts


### PR DESCRIPTION
现在的arm64架构产物过于巨大，而dart 3.9很好的解决了这个问题