### PR TITLE
修复Star History图表

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,4 +96,4 @@ dart compile exe bin/main.dart -o ./build/bili_novel_packer
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=Montaro2017/bili_novel_packer&type=Date)](https://www.star-history.com/#Montaro2017/bili_novel_packer&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=Montaro2017/bili_novel_packer&type=Date)](https://star-history.dera.page/#Montaro2017/bili_novel_packer&Date)


### PR DESCRIPTION
当前的Star History图表因为GitHub限制已经无法正常显示，本项目是一个开源项目，Star数量对项目至关重要。此改动将图表和链接更新到可用的地址，恢复Star History功能。